### PR TITLE
Problem: Broken link to Atmosphere and iPlant name change

### DIFF
--- a/lessons/0.cloud-introduction.md
+++ b/lessons/0.cloud-introduction.md
@@ -398,9 +398,9 @@ Cloud](https://raw.githubusercontent.com/datacarpentry/cloud-genomics/gh-pages/l
 -   Amazon EC2: <http://aws.amazon.com/ec2/>
 -   Microsoft Azure: <https://azure.microsoft.com/en-us/>
 -   Google Cloud Platform: <https://cloud.google.com/>
--   iPlant's Atmosphere:
-    <http://www.iplantcollaborative.org/ci/atmosphere>
--   iPlant's help page:
+-   CyVerse (was iPlant) Atmosphere:
+    <http://www.cyverse.org/atmosphere>
+-   CyVerse Atmosphere help page:
     <https://pods.iplantcollaborative.org/wiki/display/atmman/Atmosphere+Manual+Table+of+Contents>
 -   HPC offerings:
 -   XSEDE: <https://www.xsede.org/high-performance-computing>


### PR DESCRIPTION
iPlant Collaborative has been renamed to CyVerse.

Solution: Fixed broken link and changed iPlant to CyVerse in the text.