### PR TITLE
Problem: iPlant Collaborative is now called CyVerse

### DIFF
--- a/lessons/1.logging-onto-cloud.md
+++ b/lessons/1.logging-onto-cloud.md
@@ -148,17 +148,17 @@ When you are finished with your instance, you must terminate. Follow the followi
 
     > **Warning:** This will delete any data on this instance, so you must move any data you wish to save off the instance.
 
-    >  **Tip:** You can use iCommands to move data between your computer, a cloud instance, and the iPlant Data Store. iCommands is installed on the Data Carpentry Amazon AMI. You can download and see documentation for iCommands [here](https://pods.iplantcollaborative.org/wiki/display/DS/Using+iCommands) - there is also some documentation on setting up iCommands in the Atmosphere section below
+    >  **Tip:** You can use iCommands to move data between your computer, a cloud instance, and the CyVerse Data Store. iCommands is installed on the Data Carpentry Amazon AMI. You can download and see documentation for iCommands [here](https://pods.iplantcollaborative.org/wiki/display/DS/Using+iCommands) - there is also some documentation on setting up iCommands in the Atmosphere section below
 5. Select 'Yes, Terminate' to terminate the instance. 
 
 ### Launching an instance on Atmosphere
 
 **Prerequisites**
 
-* You must have an iPlant account (register at [http://user.iplantcollaborative.org/](http://user.iplantcollaborative.org/) ) - You must also request access to Atmosphere (see [documentation](https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+Access+to+Atmosphere) **iPlant requires Atmosphere users to have a valid .edu or .org email address** ) 
+* You must have a CyVerse account (register at [https://user.cyverse.org/](https://user.cyverse.org/) ) - You must also request access to Atmosphere (see [documentation](https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+Access+to+Atmosphere) **CyVerse requires Atmosphere users to have a valid .edu or .org email address** ) 
 
 #### Sign into Atmosphere and launch an instance
-1. Sign into Atmosphere at: [http://atmo.iplantcollaborative.org/](http://atmo.iplantcollaborative.org/)
+1. Sign into Atmosphere at: [http://atmo.cyverse.org/](https://atmo.cyverse.org/)
 2. Under 'Select an Image', search for the 'TSW Workshop Williams 1.2' image; Select this image. 
     ![](./images/logging-onto-cloud_8.png)
 3. Under instance size select **'small2'** size. 
@@ -174,16 +174,16 @@ Your instance should be ready in 10-15 minutes. When your instance status is lis
 
 **Instructions for MAC**
 
-1. If necessary, log into your Atmosphere at: [http://atmo.iplantcollaborative.org/](http://atmo.iplantcollaborative.org/)
+1. If necessary, log into your Atmosphere at: [https://atmo.cyverse.org/](https://atmo.cyverse.org/)
 2. Verifying that your instance status is **'active'**, copy the IP address (e.g. 128.123.12.34) to your clipboard. 
     ![](./images/logging-onto-cloud_10.png)
 3. Open the terminal application on your Mac and use 'ssh' to connect. Your command will be:
 
     ```bash
-$ ssh iplantusername@your.atmosphere.ipaddress
+$ ssh cyverse_username@your.atmosphere.ipaddress
 ```
 5. Your computer will be unable to verify the authenticity of the host... type **yes** to continue connecting
-6. When prompted for a password, enter your iPlant username. 
+6. When prompted for a password, enter your CyVerse username. 
 
 You should now be connected to your personal instance. You can confirm this with the following commands; ``whoami``,``pwd``, which should yield the following results:
 
@@ -206,22 +206,22 @@ The user manual is located here: http://goo.gl/2pT72
 For assistance, contact support@iplantcollaborative.org.  
 
 Last login: Fri Aug 14 10:16:50 2015 from dhcp140-78.cshl.edu
-iplantusername@vm65-164:~$ whoami
-iplantusername
-iplantusername@vm65-164:~$ pwd
-/home/iplantusername
+cyverse_username@vm65-164:~$ whoami
+cyverse_username
+cyverse_username@vm65-164:~$ pwd
+/home/cyverse_username
 ```
-**Note**: In the above example 'iplantusername' will be your actual iPlant username. 
+**Note**: In the above example 'cyverse_username' will be your actual CyVerse username. 
 
 **Instructions for PC**
 
 1. Download the PuTTY application at: [http://the.earth.li/~sgtatham/putty/latest/x86/putty.exe](http://the.earth.li/~sgtatham/putty/latest/x86/putty.exe)
-1. If necessary, log into your Atmosphere at: [http://atmo.iplantcollaborative.org/](http://atmo.iplantcollaborative.org/)
+1. If necessary, log into your Atmosphere at: [https://atmo.cyverse.org/](https://atmo.cyverse.org/)
 2. Verifying that your instance status is **'active'**, copy the IP address (e.g. 128.123.12.34) to your clipboard. 
     ![](./images/logging-onto-cloud_10.png)
 4. Start PuTTY. In the section 'Specify the destination you want to connect to' for 'Host Name (or IP address)' paste in the DNS address and click 'Open'
-5. When prompted to login as, enter your iPlant username; you may be notified that the authenticity of the host cannot be verified - if so, ignore the warning an continue connecting
-6. When prompted for a password enter your iPlant password. 
+5. When prompted to login as, enter your CyVerse username; you may be notified that the authenticity of the host cannot be verified - if so, ignore the warning an continue connecting
+6. When prompted for a password enter your CyVerse password. 
 
 You should now be connected to your personal instance. You can confirm this with the following commands; ``whoami``,``pwd``, which should yield the following results:
 
@@ -244,17 +244,17 @@ The user manual is located here: http://goo.gl/2pT72
 For assistance, contact support@iplantcollaborative.org.  
 
 Last login: Fri Aug 14 10:16:50 2015 from dhcp140-78.cshl.edu
-iplantusername@vm65-164:~$ whoami
-iplantusername
-iplantusername@vm65-164:~$ pwd
-/home/iplantusername
+cyverse_username@vm65-164:~$ whoami
+cyverse_username
+cyverse_username@vm65-164:~$ pwd
+/home/cyverse_username
 ```
-**Note**: In the above example 'iplantusername' will be your actual iPlant username. 
+**Note**: In the above example 'cyverse_username' will be your actual CyVerse username. 
 
 
 #### Bringing sample data into your Atmosphere instance
 
-The sample dataset is **NOT** included on the Atmosphere instance. The very first time you load the instance, you will need to copy data from the public iPlant Data Store into your instance using the following instructions. 
+The sample dataset is **NOT** included on the Atmosphere instance. The very first time you load the instance, you will need to copy data from the public CyVerse Data Store into your instance using the following instructions. 
 
 ## Setup iCommands
 
@@ -275,9 +275,9 @@ $ iinit
 |irodsHost|data.iplantcollaborative.org|
 |port|1247|
 |zone|iplant|
-|irodsUserName|your iplant username|
-|Current iRODS password|your iplant password|
-3. Verify that you have connected to your iPlant Data Store; view the contents of your home directory using the following the ``ils`` command:
+|irodsUserName|your CyVerse username|
+|Current iRODS password|your CyVerse password|
+3. Verify that you have connected to your CyVerse Data Store; view the contents of your home directory using the following the ``ils`` command:
 
     ```bash
 $ ils
@@ -292,13 +292,13 @@ $ iget -rPVT /iplant/home/shared/iplant_training/data_carpentry_ngs/dc_sampledat
 2. using ``ls`` you should be able to verify you have downloaded the dc_sampledata_lite directories and files. 
 
 
-> **Tip**: You can use iCommands to move data between your computer, a cloud instance, and the iPlant Data Store. iCommands is installed on the Data Carpentry Amazon AMI. You can download and see documentation for iCommands [here](https://pods.iplantcollaborative.org/wiki/display/DS/Using+iCommands) 
+> **Tip**: You can use iCommands to move data between your computer, a cloud instance, and the CyVerse Data Store. iCommands is installed on the Data Carpentry Amazon AMI. You can download and see documentation for iCommands [here](https://pods.iplantcollaborative.org/wiki/display/DS/Using+iCommands) 
 
 ### Terminating your Atmosphere instance
 
 When you are finished with your instance, you must terminate. Follow the following steps. 
 
-1. If necessary, sign into Atmosphere: [http://atmo.iplantcollaborative.org/](http://atmo.iplantcollaborative.org/)
+1. If necessary, sign into Atmosphere: [https://atmo.cyverse.org/](https://atmo.cyverse.org/)
 2. Under 'My Instances' select the instance you wish to terminate and the click the black 'X' or find the 'Terminate' button and click. 
 
     > **Warning:** This will delete any data on this instance, so you must move any data you wish to save off the instance (for example by using iCommands). 


### PR DESCRIPTION
Some of the links are broken after the name change.

Solution: Fixed the links. Also changed most mentions of iplant/iPlant to cyverse/CyVerse where it makes sense, and where the change has happened.

Note: More changes in the future when the Data Store paths and the wiki domain change to using CyVerse instead of the iPlant.