### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3260674.svg)](https://doi.org/10.5281/zenodo.3260674)
 
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--genomics--cloud-E01563.svg)](https://swcarpentry.slack.com/messages/C9WDV4C9W)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--genomics--cloud-E01563.svg)](https://carpentries.slack.com/messages/C9WDV4C9W)
 
 # cloud-genomics
 


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.