### PR TITLE
fix: correct 'Log onto to' → 'Log on to' in objectives

### DIFF
--- a/episodes/02-logging-onto-cloud.md
+++ b/episodes/02-logging-onto-cloud.md
@@ -6,7 +6,7 @@ exercises: 5
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Log onto to a running instance
+- Log on to a running instance
 - Log off from a running instance
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
## Summary

Fixes #139

The first objective in `episodes/02-logging-onto-cloud.md` had a duplicate preposition:

**Before:** `- Log onto to a running instance`
**After:** `- Log on to a running instance`